### PR TITLE
Add toolbar and accent color pickers, fix low-contrast defaults

### DIFF
--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/AboutActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/AboutActivityTest.kt
@@ -33,4 +33,11 @@ class AboutActivityTest : TestCase() {
   fun upButtonFinishesActivity() = run {
     step("Verify toolbar with navigation is shown") { AboutScreen { toolbar.isVisible() } }
   }
+
+  @Test
+  fun applicationInfoLinksToTheCurrentFork() = run {
+    step("Verify the application info text links to this fork's repository") {
+      AboutScreen { applicationInfoText.containsText("github.com/growse/materialistic-nouveau") }
+    }
+  }
 }

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
@@ -6,8 +6,10 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.google.android.material.color.DynamicColors
 import com.growse.android.io.github.hidroh.materialistic.screens.DisplayPreferencesScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExternalResource
@@ -92,6 +94,29 @@ class DisplayPreferencesActivityTest : TestCase() {
           PreferenceManager.getDefaultSharedPreferences(context)
               .getString(context.getString(R.string.pref_primary_color), null)
       assert(persisted == null) { "Expected pref_primary_color to remain unset, was '$persisted'" }
+    }
+  }
+
+  @Test
+  fun systemSwatchIsOfferedOnlyWhenDynamicColorIsAvailable() = run {
+    // Skips cleanly (not a failure) on a device/emulator without Material You dynamic color,
+    // e.g. anything pre-Android 12 - see ColorPreference.buildSwatches.
+    assumeTrue(DynamicColors.isDynamicColorAvailable())
+    val systemSwatchDescription =
+        "${context.getString(R.string.pref_primary_color_title)} ${context.getString(R.string.color_system)}"
+    step("Tap the toolbar color picker's System swatch") {
+      DisplayPreferencesScreen { swatch(systemSwatchDescription).click() }
+    }
+    step("Verify the summary now reads System") {
+      DisplayPreferencesScreen {
+        summaryWithText(context.getString(R.string.color_system)).isVisible()
+      }
+    }
+    step("Verify the choice was persisted") {
+      val persisted =
+          PreferenceManager.getDefaultSharedPreferences(context)
+              .getString(context.getString(R.string.pref_primary_color), null)
+      assert(persisted == "system") { "Expected pref_primary_color to be persisted as 'system'" }
     }
   }
 }

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
@@ -1,0 +1,97 @@
+package com.growse.android.io.github.hidroh.materialistic
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.growse.android.io.github.hidroh.materialistic.screens.DisplayPreferencesScreen
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
+
+class DisplayPreferencesActivityTest : TestCase() {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  // Each ColorPreference persists its choice to the app's default SharedPreferences, which
+  // outlives any single Activity instance. Cleared as an outer rule (rather than @Before) so it
+  // runs before ActivityScenarioRule launches the activity, not after - otherwise a prior test's
+  // leftover selection would already be bound into the freshly-launched screen.
+  private val clearColorPreferencesRule =
+      object : ExternalResource() {
+        override fun before() {
+          PreferenceManager.getDefaultSharedPreferences(context).edit {
+            remove(context.getString(R.string.pref_primary_color))
+            remove(context.getString(R.string.pref_accent_color))
+          }
+        }
+      }
+
+  private val activityScenarioRule =
+      ActivityScenarioRule<PreferencesActivity>(
+          Intent(context, PreferencesActivity::class.java)
+              .putExtra(PreferencesActivity.EXTRA_TITLE, R.string.display)
+              .putExtra(PreferencesActivity.EXTRA_PREFERENCES, R.xml.preferences_display)
+      )
+
+  @get:Rule
+  val rules: RuleChain = RuleChain.outerRule(clearColorPreferencesRule).around(activityScenarioRule)
+
+  @Test
+  fun colorPickersAreVisibleWithDefaultSummaries() = run {
+    step("Verify the toolbar color picker defaults to Purple") {
+      DisplayPreferencesScreen {
+        primaryColorTitle.isVisible()
+        summaryWithText(context.getString(R.string.color_purple)).isVisible()
+      }
+    }
+    step("Verify the accent color picker defaults to Red") {
+      DisplayPreferencesScreen {
+        accentColorTitle.isVisible()
+        summaryWithText(context.getString(R.string.color_red)).isVisible()
+      }
+    }
+  }
+
+  @Test
+  fun tappingATealSwatchUpdatesTheToolbarColorSelection() = run {
+    val tealSwatchDescription =
+        "${context.getString(R.string.pref_primary_color_title)} ${context.getString(R.string.color_teal)}"
+    step("Tap the toolbar color picker's Teal swatch") {
+      DisplayPreferencesScreen { swatch(tealSwatchDescription).click() }
+    }
+    step("Verify the summary now reads Teal") {
+      DisplayPreferencesScreen {
+        summaryWithText(context.getString(R.string.color_teal)).isVisible()
+      }
+    }
+    step("Verify the choice was persisted") {
+      val persisted =
+          PreferenceManager.getDefaultSharedPreferences(context)
+              .getString(context.getString(R.string.pref_primary_color), null)
+      assert(persisted == "teal") { "Expected pref_primary_color to be persisted as 'teal'" }
+    }
+  }
+
+  @Test
+  fun accentColorSelectionIsIndependentOfToolbarColor() = run {
+    val tealSwatchDescription =
+        "${context.getString(R.string.pref_accent_color_title)} ${context.getString(R.string.color_teal)}"
+    step("Tap the accent color picker's Teal swatch") {
+      DisplayPreferencesScreen { swatch(tealSwatchDescription).click() }
+    }
+    // Checked against SharedPreferences rather than the on-screen summary: tapping the lower
+    // (accent) row can scroll the toolbar color row out of the RecyclerView's inflated window,
+    // making its summary TextView unavailable to Espresso even though nothing changed.
+    step("Verify the toolbar color preference itself is unaffected") {
+      val persisted =
+          PreferenceManager.getDefaultSharedPreferences(context)
+              .getString(context.getString(R.string.pref_primary_color), null)
+      assert(persisted == null) { "Expected pref_primary_color to remain unset, was '$persisted'" }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
@@ -5,10 +5,16 @@ import android.content.Intent
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.google.android.material.color.DynamicColors
 import com.growse.android.io.github.hidroh.materialistic.screens.DisplayPreferencesScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.hamcrest.Matchers.allOf
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -45,17 +51,39 @@ class DisplayPreferencesActivityTest : TestCase() {
 
   @Test
   fun colorPickersAreVisibleWithDefaultSummaries() = run {
-    step("Verify the toolbar color picker defaults to Purple") {
-      DisplayPreferencesScreen {
-        primaryColorTitle.isVisible()
-        summaryWithText(context.getString(R.string.color_purple)).isVisible()
-      }
+    // Preferences.Theme.defaultColorChoice prefers "system" wherever dynamic color is available,
+    // falling back to the fixed swatch otherwise - the summaries should track that exactly. Both
+    // pickers can legitimately show the same "System" label at once, so the summary is matched
+    // by its sibling title rather than by text alone, which would otherwise be ambiguous.
+    val defaultPrimaryLabel =
+        context.getString(
+            if (DynamicColors.isDynamicColorAvailable()) R.string.color_system
+            else R.string.color_purple
+        )
+    val defaultAccentLabel =
+        context.getString(
+            if (DynamicColors.isDynamicColorAvailable()) R.string.color_system
+            else R.string.color_red
+        )
+    step("Verify the toolbar color picker's default summary") {
+      DisplayPreferencesScreen { primaryColorTitle.isVisible() }
+      onView(
+              allOf(
+                  withText(defaultPrimaryLabel),
+                  hasSibling(withText(R.string.pref_primary_color_title)),
+              )
+          )
+          .check(matches(isDisplayed()))
     }
-    step("Verify the accent color picker defaults to Red") {
-      DisplayPreferencesScreen {
-        accentColorTitle.isVisible()
-        summaryWithText(context.getString(R.string.color_red)).isVisible()
-      }
+    step("Verify the accent color picker's default summary") {
+      DisplayPreferencesScreen { accentColorTitle.isVisible() }
+      onView(
+              allOf(
+                  withText(defaultAccentLabel),
+                  hasSibling(withText(R.string.pref_accent_color_title)),
+              )
+          )
+          .check(matches(isDisplayed()))
     }
   }
 
@@ -102,15 +130,28 @@ class DisplayPreferencesActivityTest : TestCase() {
     // Skips cleanly (not a failure) on a device/emulator without Material You dynamic color,
     // e.g. anything pre-Android 12 - see ColorPreference.buildSwatches.
     assumeTrue(DynamicColors.isDynamicColorAvailable())
+    val tealSwatchDescription =
+        "${context.getString(R.string.pref_primary_color_title)} ${context.getString(R.string.color_teal)}"
     val systemSwatchDescription =
         "${context.getString(R.string.pref_primary_color_title)} ${context.getString(R.string.color_system)}"
+    // "System" is the default (see colorPickersAreVisibleWithDefaultSummaries), so tap away from
+    // it first - otherwise tapping an already-selected swatch is a no-op and never persists.
+    step("Tap the toolbar color picker's Teal swatch") {
+      DisplayPreferencesScreen { swatch(tealSwatchDescription).click() }
+    }
     step("Tap the toolbar color picker's System swatch") {
       DisplayPreferencesScreen { swatch(systemSwatchDescription).click() }
     }
-    step("Verify the summary now reads System") {
-      DisplayPreferencesScreen {
-        summaryWithText(context.getString(R.string.color_system)).isVisible()
-      }
+    step("Verify the summary reads System again") {
+      // Not summaryWithText alone: the accent picker also defaults to "System" and is untouched
+      // by this test, so bare text would match two summaries at once.
+      onView(
+              allOf(
+                  withText(context.getString(R.string.color_system)),
+                  hasSibling(withText(R.string.pref_primary_color_title)),
+              )
+          )
+          .check(matches(isDisplayed()))
     }
     step("Verify the choice was persisted") {
       val persisted =

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/DisplayPreferencesActivityTest.kt
@@ -2,6 +2,7 @@ package com.growse.android.io.github.hidroh.materialistic
 
 import android.content.Context
 import android.content.Intent
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
@@ -25,7 +26,7 @@ class DisplayPreferencesActivityTest : TestCase() {
 
   private val context = ApplicationProvider.getApplicationContext<Context>()
 
-  // Each ColorPreference persists its choice to the app's default SharedPreferences, which
+  // Each of these preferences persists its choice to the app's default SharedPreferences, which
   // outlives any single Activity instance. Cleared as an outer rule (rather than @Before) so it
   // runs before ActivityScenarioRule launches the activity, not after - otherwise a prior test's
   // leftover selection would already be bound into the freshly-launched screen.
@@ -35,6 +36,8 @@ class DisplayPreferencesActivityTest : TestCase() {
           PreferenceManager.getDefaultSharedPreferences(context).edit {
             remove(context.getString(R.string.pref_primary_color))
             remove(context.getString(R.string.pref_accent_color))
+            remove(context.getString(R.string.pref_theme))
+            remove(context.getString(R.string.pref_daynight_auto))
           }
         }
       }
@@ -48,6 +51,28 @@ class DisplayPreferencesActivityTest : TestCase() {
 
   @get:Rule
   val rules: RuleChain = RuleChain.outerRule(clearColorPreferencesRule).around(activityScenarioRule)
+
+  @Test
+  fun themeDefaultsToSystemWithAutoDayNightImplied() = run {
+    step("Verify the theme picker defaults to System") {
+      DisplayPreferencesScreen { themeTitle.isVisible() }
+      onView(
+              allOf(
+                  withText(R.string.theme_system),
+                  hasSibling(withText(R.string.pref_theme_title)),
+              )
+          )
+          .check(matches(isDisplayed()))
+    }
+    step("Verify day/night follows the OS by default, without needing the separate toggle") {
+      // The default state has neither pref_theme nor pref_daynight_auto persisted yet - this is
+      // exactly what a fresh install resolves to.
+      val mode = Preferences.Theme.getAutoDayNightMode(context)
+      assert(mode == AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM) {
+        "Expected MODE_NIGHT_FOLLOW_SYSTEM by default, was $mode"
+      }
+    }
+  }
 
   @Test
   fun colorPickersAreVisibleWithDefaultSummaries() = run {

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/LauncherIconSyncTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/LauncherIconSyncTest.kt
@@ -1,0 +1,80 @@
+package com.growse.android.io.github.hidroh.materialistic
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies Preferences.Theme.syncLauncherIcon flips exactly one of .LauncherActivity or its
+ * color-swatch activity-aliases (AndroidManifest.xml) to enabled, matching pref_primary_color.
+ */
+@RunWith(AndroidJUnit4::class)
+class LauncherIconSyncTest {
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+  private val packageManager = context.packageManager
+
+  private val allComponents =
+      listOf(
+              "LauncherActivity",
+              "LauncherAliasRed",
+              "LauncherAliasIndigo",
+              "LauncherAliasBlue",
+              "LauncherAliasTeal",
+              "LauncherAliasBrown",
+          )
+          .map { ComponentName(context.packageName, "${context.packageName}.$it") }
+
+  @Before
+  @After
+  fun clearPrimaryColorPreference() {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      remove(context.getString(R.string.pref_primary_color))
+    }
+  }
+
+  private fun enabledComponentName(): String? {
+    val enabled = allComponents.filter {
+      packageManager.getComponentEnabledSetting(it) !=
+          PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+    }
+    assert(enabled.size == 1) { "Expected exactly one enabled launcher component, got $enabled" }
+    return enabled.single().className.substringAfterLast('.')
+  }
+
+  @Test
+  fun defaultsToTheBaseLauncherActivity() {
+    Preferences.Theme.syncLauncherIcon(context)
+    assert(enabledComponentName() == "LauncherActivity")
+  }
+
+  @Test
+  fun tealPreferenceEnablesTheTealAlias() {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putString(context.getString(R.string.pref_primary_color), "teal")
+    }
+    Preferences.Theme.syncLauncherIcon(context)
+    assert(enabledComponentName() == "LauncherAliasTeal")
+  }
+
+  @Test
+  fun switchingBackToPurpleReEnablesTheBaseActivity() {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putString(context.getString(R.string.pref_primary_color), "teal")
+    }
+    Preferences.Theme.syncLauncherIcon(context)
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putString(context.getString(R.string.pref_primary_color), "purple")
+    }
+    Preferences.Theme.syncLauncherIcon(context)
+    assert(enabledComponentName() == "LauncherActivity")
+  }
+}

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/LauncherIconSyncTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/LauncherIconSyncTest.kt
@@ -77,4 +77,47 @@ class LauncherIconSyncTest {
     Preferences.Theme.syncLauncherIcon(context)
     assert(enabledComponentName() == "LauncherActivity")
   }
+
+  // Regression test for disabling an activity-alias closing the task it launched (see
+  // syncLauncherIcon's kdoc): if the alias that just launched the current task would otherwise
+  // be disabled, it must be left alone instead.
+  @Test
+  fun neverDisablesTheComponentThatLaunchedTheCurrentTask() {
+    val redAlias = ComponentName(context.packageName, "${context.packageName}.LauncherAliasRed")
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putString(context.getString(R.string.pref_primary_color), "red")
+    }
+    Preferences.Theme.syncLauncherIcon(context)
+    assert(
+        packageManager.getComponentEnabledSetting(redAlias) !=
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+    ) {
+      "Precondition failed: red alias should be enabled before switching away from it"
+    }
+
+    // Switch the preference to Teal, as if from within a task that was launched via the Red
+    // alias - simulating the exact scenario where naively disabling Red would close that task.
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putString(context.getString(R.string.pref_primary_color), "teal")
+    }
+    Preferences.Theme.syncLauncherIcon(context, redAlias)
+
+    assert(
+        packageManager.getComponentEnabledSetting(redAlias) !=
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+    ) {
+      "The component that launched the current task must never be disabled by syncLauncherIcon"
+    }
+    val tealAlias = ComponentName(context.packageName, "${context.packageName}.LauncherAliasTeal")
+    assert(
+        packageManager.getComponentEnabledSetting(tealAlias) ==
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+    ) {
+      "The new target should still be enabled even though the old one was skipped"
+    }
+
+    // Clean up the intentionally-left-enabled Red alias so later tests in this class still see
+    // exactly one enabled component, as if a later cold start (no protected component) reconciled.
+    Preferences.Theme.syncLauncherIcon(context)
+  }
 }

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivityTest.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivityTest.kt
@@ -2,6 +2,7 @@ package com.growse.android.io.github.hidroh.materialistic
 
 import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.platform.app.InstrumentationRegistry
 import com.growse.android.io.github.hidroh.materialistic.screens.ReleaseNotesScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Rule
@@ -15,6 +16,17 @@ class ReleaseNotesActivityTest : TestCase() {
   fun webViewIsDisplayed() = run {
     step("Verify the release notes WebView is visible") {
       ReleaseNotesScreen { webView.isVisible() }
+    }
+  }
+
+  @Test
+  fun openingTheScreenMarksReleaseNotesAsSeen() = run {
+    step("Verify the release-notes-seen preference is set once the screen is shown") {
+      assert(
+          Preferences.isReleaseNotesSeen(InstrumentationRegistry.getInstrumentation().targetContext)
+      ) {
+        "Release notes should be marked as seen after ReleaseNotesActivity is shown"
+      }
     }
   }
 

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/screens/DisplayPreferencesScreen.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/screens/DisplayPreferencesScreen.kt
@@ -10,6 +10,7 @@ object DisplayPreferencesScreen : KScreen<DisplayPreferencesScreen>() {
   override val layoutId = R.layout.activity_preferences
   override val viewClass = PreferencesActivity::class.java
 
+  val themeTitle = KTextView { withText(R.string.pref_theme_title) }
   val primaryColorTitle = KTextView { withText(R.string.pref_primary_color_title) }
   val accentColorTitle = KTextView { withText(R.string.pref_accent_color_title) }
 

--- a/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/screens/DisplayPreferencesScreen.kt
+++ b/app/src/androidTest/java/com/growse/android/io/github/hidroh/materialistic/screens/DisplayPreferencesScreen.kt
@@ -1,0 +1,20 @@
+package com.growse.android.io.github.hidroh.materialistic.screens
+
+import com.growse.android.io.github.hidroh.materialistic.PreferencesActivity
+import com.growse.android.io.github.hidroh.materialistic.R
+import com.kaspersky.kaspresso.screens.KScreen
+import io.github.kakaocup.kakao.common.views.KView
+import io.github.kakaocup.kakao.text.KTextView
+
+object DisplayPreferencesScreen : KScreen<DisplayPreferencesScreen>() {
+  override val layoutId = R.layout.activity_preferences
+  override val viewClass = PreferencesActivity::class.java
+
+  val primaryColorTitle = KTextView { withText(R.string.pref_primary_color_title) }
+  val accentColorTitle = KTextView { withText(R.string.pref_accent_color_title) }
+
+  fun summaryWithText(text: String) = KTextView { withText(text) }
+
+  /** [contentDescription] is "<preference title> <swatch label>", e.g. "Toolbar color Teal". */
+  fun swatch(contentDescription: String) = KView { withContentDescription(contentDescription) }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,92 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+        <!-- One alias per fixed toolbar-color swatch, giving the home-screen icon a matching
+             background. Exactly one of these plus .LauncherActivity's own intent-filter above is
+             ever enabled at a time - see Preferences.Theme.syncLauncherIcon, which the "purple"
+             and "system" choices leave pointed at .LauncherActivity itself since that's already
+             purple and already carries the adaptive icon's monochrome layer for the OS's own
+             wallpaper-based icon theming. -->
+        <activity-alias
+            android:name=".LauncherAliasRed"
+            android:targetActivity=".LauncherActivity"
+            android:icon="@mipmap/ic_launcher_red"
+            android:roundIcon="@mipmap/ic_launcher_red_round"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
+        <activity-alias
+            android:name=".LauncherAliasIndigo"
+            android:targetActivity=".LauncherActivity"
+            android:icon="@mipmap/ic_launcher_indigo"
+            android:roundIcon="@mipmap/ic_launcher_indigo_round"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
+        <activity-alias
+            android:name=".LauncherAliasBlue"
+            android:targetActivity=".LauncherActivity"
+            android:icon="@mipmap/ic_launcher_blue"
+            android:roundIcon="@mipmap/ic_launcher_blue_round"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
+        <activity-alias
+            android:name=".LauncherAliasTeal"
+            android:targetActivity=".LauncherActivity"
+            android:icon="@mipmap/ic_launcher_teal"
+            android:roundIcon="@mipmap/ic_launcher_teal_round"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
+        <activity-alias
+            android:name=".LauncherAliasBrown"
+            android:targetActivity=".LauncherActivity"
+            android:icon="@mipmap/ic_launcher_brown"
+            android:roundIcon="@mipmap/ic_launcher_brown_round"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
         <activity
             android:name=".ListActivity"
             android:label="@string/title_activity_list">

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
@@ -16,6 +16,7 @@
 package com.growse.android.io.github.hidroh.materialistic
 
 import android.annotation.SuppressLint
+import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
@@ -456,16 +457,23 @@ object Preferences {
       if (themeSpec.themeOverrides >= 0) {
         context.getTheme().applyStyle(themeSpec.themeOverrides, true)
       }
-      getPrimaryColorOverlay(get(context, R.string.pref_primary_color, "purple"))?.let {
-        context.getTheme().applyStyle(it, true)
-      }
-      getAccentColorOverlay(get(context, R.string.pref_accent_color, "red"))?.let {
-        context.getTheme().applyStyle(it, true)
-      }
+      getPrimaryColorOverlay(
+              get(context, R.string.pref_primary_color, defaultColorChoice("purple"))
+          )
+          ?.let { context.getTheme().applyStyle(it, true) }
+      getAccentColorOverlay(get(context, R.string.pref_accent_color, defaultColorChoice("red")))
+          ?.let { context.getTheme().applyStyle(it, true) }
       if (dialogTheme) {
         context.setTheme(AppUtils.getThemedResId(context, R.attr.alertDialogTheme))
       }
     }
+
+    // Devices/users that never open Settings never persist a color choice, so this - not
+    // ColorPreference's own default - is what most people actually see: prefer the wallpaper-
+    // derived system color where it's available, falling back to the fixed swatch otherwise.
+    @JvmStatic
+    fun defaultColorChoice(fallback: String): String =
+        if (DynamicColors.isDynamicColorAvailable()) "system" else fallback
 
     @StyleRes
     private fun getPrimaryColorOverlay(name: String): Int? =
@@ -496,6 +504,47 @@ object Preferences {
           "brown" -> R.style.AccentColorOverlay_Brown
           else -> null
         }
+
+    // Manifest activity-alias suffixes (see AndroidManifest.xml) for each toolbar color that has
+    // its own launcher icon. "purple" and "system" have no entry: both leave .LauncherActivity
+    // itself enabled, since its default icon is already purple and already carries the adaptive
+    // icon's monochrome layer that the OS's own wallpaper-based icon theming re-tints for
+    // "system" when the user has that OS feature on.
+    private val LAUNCHER_ALIASES =
+        mapOf(
+            "red" to "LauncherAliasRed",
+            "indigo" to "LauncherAliasIndigo",
+            "blue" to "LauncherAliasBlue",
+            "teal" to "LauncherAliasTeal",
+            "brown" to "LauncherAliasBrown",
+        )
+
+    /**
+     * Enables the launcher activity-alias matching the current toolbar color choice and disables
+     * the rest, so the home-screen icon matches. Touches disk via PackageManager - call off the
+     * main thread.
+     */
+    @JvmStatic
+    fun syncLauncherIcon(context: Context) {
+      val appContext = context.applicationContext
+      val packageManager = appContext.packageManager
+      val packageName = appContext.packageName
+      val colorName = get(appContext, R.string.pref_primary_color, defaultColorChoice("purple"))
+      val activeClassName = LAUNCHER_ALIASES[colorName] ?: "LauncherActivity"
+      for (className in setOf("LauncherActivity") + LAUNCHER_ALIASES.values) {
+        val component = ComponentName(packageName, "$packageName.$className")
+        val desiredState =
+            if (className == activeClassName) PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        if (packageManager.getComponentEnabledSetting(component) != desiredState) {
+          packageManager.setComponentEnabledSetting(
+              component,
+              desiredState,
+              PackageManager.DONT_KILL_APP,
+          )
+        }
+      }
+    }
 
     @JvmStatic
     fun getTypeface(context: Context): String {

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
@@ -30,6 +30,7 @@ import androidx.core.content.edit
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceManager
+import com.google.android.material.color.DynamicColors
 import com.growse.android.io.github.hidroh.materialistic.annotation.PublicApi
 import com.growse.android.io.github.hidroh.materialistic.annotation.Synthetic
 import com.growse.android.io.github.hidroh.materialistic.data.AlgoliaPopularClient
@@ -469,6 +470,9 @@ object Preferences {
     @StyleRes
     private fun getPrimaryColorOverlay(name: String): Int? =
         when (name) {
+          "system" ->
+              if (DynamicColors.isDynamicColorAvailable()) R.style.PrimaryColorOverlay_System
+              else R.style.PrimaryColorOverlay_Purple
           "purple" -> R.style.PrimaryColorOverlay_Purple
           "red" -> R.style.PrimaryColorOverlay_Red
           "indigo" -> R.style.PrimaryColorOverlay_Indigo
@@ -481,6 +485,9 @@ object Preferences {
     @StyleRes
     private fun getAccentColorOverlay(name: String): Int? =
         when (name) {
+          "system" ->
+              if (DynamicColors.isDynamicColorAvailable()) R.style.AccentColorOverlay_System
+              else R.style.AccentColorOverlay_Red
           "purple" -> R.style.AccentColorOverlay_Purple
           "red" -> R.style.AccentColorOverlay_Red
           "indigo" -> R.style.AccentColorOverlay_Indigo

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
@@ -455,10 +455,40 @@ object Preferences {
       if (themeSpec.themeOverrides >= 0) {
         context.getTheme().applyStyle(themeSpec.themeOverrides, true)
       }
+      getPrimaryColorOverlay(get(context, R.string.pref_primary_color, "purple"))?.let {
+        context.getTheme().applyStyle(it, true)
+      }
+      getAccentColorOverlay(get(context, R.string.pref_accent_color, "red"))?.let {
+        context.getTheme().applyStyle(it, true)
+      }
       if (dialogTheme) {
         context.setTheme(AppUtils.getThemedResId(context, R.attr.alertDialogTheme))
       }
     }
+
+    @StyleRes
+    private fun getPrimaryColorOverlay(name: String): Int? =
+        when (name) {
+          "purple" -> R.style.PrimaryColorOverlay_Purple
+          "red" -> R.style.PrimaryColorOverlay_Red
+          "indigo" -> R.style.PrimaryColorOverlay_Indigo
+          "blue" -> R.style.PrimaryColorOverlay_Blue
+          "teal" -> R.style.PrimaryColorOverlay_Teal
+          "brown" -> R.style.PrimaryColorOverlay_Brown
+          else -> null
+        }
+
+    @StyleRes
+    private fun getAccentColorOverlay(name: String): Int? =
+        when (name) {
+          "purple" -> R.style.AccentColorOverlay_Purple
+          "red" -> R.style.AccentColorOverlay_Red
+          "indigo" -> R.style.AccentColorOverlay_Indigo
+          "blue" -> R.style.AccentColorOverlay_Blue
+          "teal" -> R.style.AccentColorOverlay_Teal
+          "brown" -> R.style.AccentColorOverlay_Brown
+          else -> null
+        }
 
     @JvmStatic
     fun getTypeface(context: Context): String {

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
@@ -602,6 +602,11 @@ object Preferences {
 
     @JvmStatic
     fun getAutoDayNightMode(context: Context): Int {
+      // "System" (the default) always follows the OS, independent of the pref_daynight_auto
+      // toggle below, which stays available for other DayNight-capable themes (e.g. Sepia).
+      if (ThemePreference.isSystemTheme(get(context, R.string.pref_theme, ""))) {
+        return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+      }
       return if (
           getTheme(context, false) is DayNightSpec &&
               get(context, R.string.pref_daynight_auto, false)

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/Preferences.kt
@@ -523,9 +523,18 @@ object Preferences {
      * Enables the launcher activity-alias matching the current toolbar color choice and disables
      * the rest, so the home-screen icon matches. Touches disk via PackageManager - call off the
      * main thread.
+     *
+     * [launchedViaComponent], when given, is skipped even if it should be disabled: disabling the
+     * exact component that launched the currently-running task closes that task outright (an
+     * activity-alias, once disabled, no longer resolves at all - see
+     * ActivityTaskManager/WindowManagerShell logs showing a CLOSE transition for the task the
+     * moment PackageManager reports the alias gone). DONT_KILL_APP only protects the process, not
+     * the task. Skipping it here just defers that one disable to the next cold start, once this
+     * task is no longer using it.
      */
     @JvmStatic
-    fun syncLauncherIcon(context: Context) {
+    @JvmOverloads
+    fun syncLauncherIcon(context: Context, launchedViaComponent: ComponentName? = null) {
       val appContext = context.applicationContext
       val packageManager = appContext.packageManager
       val packageName = appContext.packageName
@@ -536,6 +545,12 @@ object Preferences {
         val desiredState =
             if (className == activeClassName) PackageManager.COMPONENT_ENABLED_STATE_ENABLED
             else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        if (
+            desiredState == PackageManager.COMPONENT_ENABLED_STATE_DISABLED &&
+                component == launchedViaComponent
+        ) {
+          continue
+        }
         if (packageManager.getComponentEnabledSetting(component) != desiredState) {
           packageManager.setComponentEnabledSetting(
               component,

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivity.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivity.kt
@@ -23,6 +23,7 @@ import android.view.Window
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.VisibleForTesting
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -38,10 +39,10 @@ class ReleaseNotesActivity : ThemedActivity() {
       finish()
     }
     val notesBody =
-        BuildConfig.RELEASE_NOTES_HTML.split("\n")
-            .filter { it.isNotBlank() }
-            .joinToString(separator = "") { "<p>$it</p>" }
-            .ifEmpty { "<p>${getString(R.string.release_notes_unavailable)}</p>" }
+        buildNotesBody(
+            BuildConfig.RELEASE_NOTES_HTML,
+            getString(R.string.release_notes_unavailable),
+        )
     with(findViewById<WebView>(R.id.web_view)) {
       webViewClient = WebViewClient()
       webChromeClient = WebChromeClient()
@@ -68,4 +69,14 @@ class ReleaseNotesActivity : ThemedActivity() {
   }
 
   override fun isDialogTheme() = true
+
+  companion object {
+    @VisibleForTesting
+    fun buildNotesBody(rawNotes: String, unavailableMessage: String): String =
+        rawNotes
+            .split("\n")
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "") { "<p>$it</p>" }
+            .ifEmpty { "<p>$unavailableMessage</p>" }
+  }
 }

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
@@ -17,6 +17,7 @@
 package com.growse.android.io.github.hidroh.materialistic;
 
 import android.app.ActivityManager;
+import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Bundle;
@@ -116,6 +117,10 @@ public abstract class ThemedActivity extends AppCompatActivity {
     private void onThemeChanged(int key) {
         if (key == R.string.pref_daynight_auto) {
             AppCompatDelegate.setDefaultNightMode(Preferences.Theme.getAutoDayNightMode(this));
+        }
+        if (key == R.string.pref_primary_color) {
+            Context appContext = getApplicationContext();
+            new Thread(() -> Preferences.Theme.syncLauncherIcon(appContext)).start();
         }
         if (mResumed) {
             AppUtils.restart(this, true);

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
@@ -62,7 +62,8 @@ public abstract class ThemedActivity extends AppCompatActivity {
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         mThemeObservable.subscribe(this, (key, contextChanged) ->  onThemeChanged(key),
-                R.string.pref_theme, R.string.pref_daynight_auto);
+                R.string.pref_theme, R.string.pref_daynight_auto,
+                R.string.pref_primary_color, R.string.pref_accent_color);
     }
 
     @CallSuper

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/ThemedActivity.java
@@ -17,7 +17,6 @@
 package com.growse.android.io.github.hidroh.materialistic;
 
 import android.app.ActivityManager;
-import android.content.Context;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Bundle;
@@ -118,10 +117,12 @@ public abstract class ThemedActivity extends AppCompatActivity {
         if (key == R.string.pref_daynight_auto) {
             AppCompatDelegate.setDefaultNightMode(Preferences.Theme.getAutoDayNightMode(this));
         }
-        if (key == R.string.pref_primary_color) {
-            Context appContext = getApplicationContext();
-            new Thread(() -> Preferences.Theme.syncLauncherIcon(appContext)).start();
-        }
+        // The launcher icon itself is deliberately NOT synced here: this runs from whichever
+        // activity is on top of the back stack, which has no reliable way to know what component
+        // actually launched the task's root. Disabling the wrong (currently-in-use) launcher
+        // activity-alias closes the whole task outright (see Preferences.Theme.syncLauncherIcon).
+        // It's synced instead from LauncherActivity.onCreate() on the next cold start, where the
+        // launching component is known for certain.
         if (mResumed) {
             AppUtils.restart(this, true);
         } else {

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
@@ -29,6 +29,7 @@ import androidx.core.content.ContextCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import com.google.android.material.color.DynamicColors
+import com.growse.android.io.github.hidroh.materialistic.Preferences
 import com.growse.android.io.github.hidroh.materialistic.R
 
 private data class Swatch(val name: String, val label: CharSequence, @ColorInt val color: Int)
@@ -52,7 +53,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
   }
 
   override fun onGetDefaultValue(a: TypedArray, index: Int): Any =
-      a.getString(index) ?: swatches[0].name
+      Preferences.Theme.defaultColorChoice(a.getString(index) ?: swatches[0].name)
 
   override fun onSetInitialValue(defaultValue: Any?) {
     selected = getPersistedString((defaultValue as? String) ?: swatches[0].name)

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
@@ -78,7 +78,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                     shape = GradientDrawable.OVAL
                     setColor(color)
                   }
-              contentDescription = labels[i]
+              // Prefixed with the preference's own title so a screen reader (and Espresso, in
+              // tests) can tell the toolbar and accent swatches apart.
+              contentDescription = "$title ${labels[i]}"
               isClickable = true
               foreground =
                   context

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2015 Ha Duy Trung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.growse.android.io.github.hidroh.materialistic.preference
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.graphics.drawable.GradientDrawable
+import android.util.AttributeSet
+import android.view.Gravity
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.growse.android.io.github.hidroh.materialistic.R
+
+/**
+ * A swatch-grid preference for picking one of a fixed set of accent colors (see
+ * [R.array.accent_color_names] / [R.array.accent_color_values]), shared by the toolbar and accent
+ * color pickers.
+ */
+class ColorPreference
+@JvmOverloads
+constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
+    Preference(context, attrs, defStyleAttr) {
+
+  private val names = context.resources.getStringArray(R.array.accent_color_names)
+  private val labels = context.resources.getTextArray(R.array.accent_color_labels)
+  private var selected: String = names[0]
+
+  init {
+    layoutResource = R.layout.preference_color
+  }
+
+  override fun onGetDefaultValue(a: TypedArray, index: Int): Any = a.getString(index) ?: names[0]
+
+  override fun onSetInitialValue(defaultValue: Any?) {
+    selected = getPersistedString((defaultValue as? String) ?: names[0])
+    updateSummary()
+  }
+
+  override fun onBindViewHolder(holder: PreferenceViewHolder) {
+    super.onBindViewHolder(holder)
+    holder.itemView.isClickable = false
+    val container = holder.findViewById(R.id.color_swatch_container) as LinearLayout
+    container.removeAllViews()
+    val swatchSize = context.resources.getDimensionPixelSize(R.dimen.color_swatch_size)
+    val checkSize = context.resources.getDimensionPixelSize(R.dimen.color_swatch_check_size)
+    val margin = context.resources.getDimensionPixelSize(R.dimen.margin)
+    val colors = context.resources.obtainTypedArray(R.array.accent_color_values)
+    try {
+      for (i in names.indices) {
+        val name = names[i]
+        val color = colors.getColor(i, 0)
+        val swatch =
+            FrameLayout(context).apply {
+              layoutParams =
+                  LinearLayout.LayoutParams(swatchSize, swatchSize).apply {
+                    marginStart = margin
+                    marginEnd = margin
+                  }
+              background =
+                  GradientDrawable().apply {
+                    shape = GradientDrawable.OVAL
+                    setColor(color)
+                  }
+              contentDescription = labels[i]
+              isClickable = true
+              foreground =
+                  context
+                      .obtainStyledAttributes(
+                          intArrayOf(android.R.attr.selectableItemBackgroundBorderless)
+                      )
+                      .let {
+                        val drawable = it.getDrawable(0)
+                        it.recycle()
+                        drawable
+                      }
+              setOnClickListener {
+                if (selected != name) {
+                  selected = name
+                  persistString(name)
+                  updateSummary()
+                  notifyChanged()
+                }
+              }
+            }
+        if (name == selected) {
+          swatch.addView(
+              ImageView(context).apply {
+                setImageResource(R.drawable.ic_check_white_24dp)
+                layoutParams = FrameLayout.LayoutParams(checkSize, checkSize, Gravity.CENTER)
+              }
+          )
+        }
+        container.addView(swatch)
+      }
+    } finally {
+      colors.recycle()
+    }
+  }
+
+  private fun updateSummary() {
+    val index = names.indexOf(selected).coerceAtLeast(0)
+    summary = labels[index]
+  }
+}

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ColorPreference.kt
@@ -24,32 +24,38 @@ import android.view.Gravity
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
+import com.google.android.material.color.DynamicColors
 import com.growse.android.io.github.hidroh.materialistic.R
+
+private data class Swatch(val name: String, val label: CharSequence, @ColorInt val color: Int)
 
 /**
  * A swatch-grid preference for picking one of a fixed set of accent colors (see
  * [R.array.accent_color_names] / [R.array.accent_color_values]), shared by the toolbar and accent
- * color pickers.
+ * color pickers. On a device with Material You dynamic color available, a "System" swatch derived
+ * from the wallpaper is appended after the fixed set.
  */
 class ColorPreference
 @JvmOverloads
 constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
     Preference(context, attrs, defStyleAttr) {
 
-  private val names = context.resources.getStringArray(R.array.accent_color_names)
-  private val labels = context.resources.getTextArray(R.array.accent_color_labels)
-  private var selected: String = names[0]
+  private val swatches = buildSwatches(context)
+  private var selected: String = swatches[0].name
 
   init {
     layoutResource = R.layout.preference_color
   }
 
-  override fun onGetDefaultValue(a: TypedArray, index: Int): Any = a.getString(index) ?: names[0]
+  override fun onGetDefaultValue(a: TypedArray, index: Int): Any =
+      a.getString(index) ?: swatches[0].name
 
   override fun onSetInitialValue(defaultValue: Any?) {
-    selected = getPersistedString((defaultValue as? String) ?: names[0])
+    selected = getPersistedString((defaultValue as? String) ?: swatches[0].name)
     updateSummary()
   }
 
@@ -61,63 +67,74 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     val swatchSize = context.resources.getDimensionPixelSize(R.dimen.color_swatch_size)
     val checkSize = context.resources.getDimensionPixelSize(R.dimen.color_swatch_check_size)
     val margin = context.resources.getDimensionPixelSize(R.dimen.margin)
-    val colors = context.resources.obtainTypedArray(R.array.accent_color_values)
-    try {
-      for (i in names.indices) {
-        val name = names[i]
-        val color = colors.getColor(i, 0)
-        val swatch =
-            FrameLayout(context).apply {
-              layoutParams =
-                  LinearLayout.LayoutParams(swatchSize, swatchSize).apply {
-                    marginStart = margin
-                    marginEnd = margin
-                  }
-              background =
-                  GradientDrawable().apply {
-                    shape = GradientDrawable.OVAL
-                    setColor(color)
-                  }
-              // Prefixed with the preference's own title so a screen reader (and Espresso, in
-              // tests) can tell the toolbar and accent swatches apart.
-              contentDescription = "$title ${labels[i]}"
-              isClickable = true
-              foreground =
-                  context
-                      .obtainStyledAttributes(
-                          intArrayOf(android.R.attr.selectableItemBackgroundBorderless)
-                      )
-                      .let {
-                        val drawable = it.getDrawable(0)
-                        it.recycle()
-                        drawable
-                      }
-              setOnClickListener {
-                if (selected != name) {
-                  selected = name
-                  persistString(name)
-                  updateSummary()
-                  notifyChanged()
+    for (entry in swatches) {
+      val swatch =
+          FrameLayout(context).apply {
+            layoutParams =
+                LinearLayout.LayoutParams(swatchSize, swatchSize).apply {
+                  marginStart = margin
+                  marginEnd = margin
                 }
+            background =
+                GradientDrawable().apply {
+                  shape = GradientDrawable.OVAL
+                  setColor(entry.color)
+                }
+            // Prefixed with the preference's own title so a screen reader (and Espresso, in
+            // tests) can tell the toolbar and accent swatches apart.
+            contentDescription = "$title ${entry.label}"
+            isClickable = true
+            foreground =
+                context
+                    .obtainStyledAttributes(
+                        intArrayOf(android.R.attr.selectableItemBackgroundBorderless)
+                    )
+                    .let {
+                      val drawable = it.getDrawable(0)
+                      it.recycle()
+                      drawable
+                    }
+            setOnClickListener {
+              if (selected != entry.name) {
+                selected = entry.name
+                persistString(entry.name)
+                updateSummary()
+                notifyChanged()
               }
             }
-        if (name == selected) {
-          swatch.addView(
-              ImageView(context).apply {
-                setImageResource(R.drawable.ic_check_white_24dp)
-                layoutParams = FrameLayout.LayoutParams(checkSize, checkSize, Gravity.CENTER)
-              }
-          )
-        }
-        container.addView(swatch)
+          }
+      if (entry.name == selected) {
+        swatch.addView(
+            ImageView(context).apply {
+              setImageResource(R.drawable.ic_check_white_24dp)
+              layoutParams = FrameLayout.LayoutParams(checkSize, checkSize, Gravity.CENTER)
+            }
+        )
       }
-    } finally {
-      colors.recycle()
+      container.addView(swatch)
     }
   }
 
   private fun updateSummary() {
-    val index = names.indexOf(selected).coerceAtLeast(0)
-    summary = labels[index]
+    summary = swatches.firstOrNull { it.name == selected }?.label ?: swatches[0].label
+  }
+
+  companion object {
+    private fun buildSwatches(context: Context): List<Swatch> {
+      val names = context.resources.getStringArray(R.array.accent_color_names)
+      val labels = context.resources.getTextArray(R.array.accent_color_labels)
+      val colors = context.resources.obtainTypedArray(R.array.accent_color_values)
+      val fixed =
+          try {
+            names.indices.map { i -> Swatch(names[i], labels[i], colors.getColor(i, 0)) }
+          } finally {
+            colors.recycle()
+          }
+      if (!DynamicColors.isDynamicColorAvailable()) {
+        return fixed
+      }
+      val systemColor = ContextCompat.getColor(context, android.R.color.system_accent1_600)
+      return fixed + Swatch("system", context.getString(R.string.color_system), systemColor)
+    }
   }
 }

--- a/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ThemePreference.java
+++ b/app/src/main/java/com/growse/android/io/github/hidroh/materialistic/preference/ThemePreference.java
@@ -33,6 +33,11 @@ import com.growse.android.io.github.hidroh.materialistic.annotation.Synthetic;
 
 public class ThemePreference extends Preference {
 
+    // "System" is a DayNightSpec identical to LIGHT's, and is the default: see isSystemTheme()
+    // and Preferences.Theme.getAutoDayNightMode(), which forces auto day-night for it regardless
+    // of the separate pref_daynight_auto toggle (which stays independently available for e.g.
+    // "Sepia + auto day-night" combos that aren't otherwise expressible).
+    private static final String SYSTEM = "system";
     private static final String LIGHT = "light";
     private static final String DARK = "dark";
     private static final String BLACK = "black";
@@ -43,6 +48,7 @@ public class ThemePreference extends Preference {
     private static final ArrayMap<Integer, String> BUTTONS = new ArrayMap<>();
     private static final ArrayMap<String, ThemeSpec> VALUES = new ArrayMap<>();
     static {
+        BUTTONS.put(R.id.theme_system, SYSTEM);
         BUTTONS.put(R.id.theme_light, LIGHT);
         BUTTONS.put(R.id.theme_dark, DARK);
         BUTTONS.put(R.id.theme_black, BLACK);
@@ -51,6 +57,7 @@ public class ThemePreference extends Preference {
         BUTTONS.put(R.id.theme_solarized, SOLARIZED);
         BUTTONS.put(R.id.theme_solarized_dark, SOLARIZED_DARK);
 
+        VALUES.put(SYSTEM, new DayNightSpec(R.string.theme_system));
         VALUES.put(LIGHT, new DayNightSpec(R.string.theme_light));
         VALUES.put(DARK, new DarkSpec(R.string.theme_dark));
         VALUES.put(BLACK, new DarkSpec(R.string.theme_black, R.style.Black));
@@ -64,8 +71,16 @@ public class ThemePreference extends Preference {
     private String mSelectedTheme;
 
     public static ThemeSpec getTheme(String value, boolean isTranslucent) {
-        ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : LIGHT);
+        ThemeSpec themeSpec = VALUES.get(VALUES.containsKey(value) ? value : SYSTEM);
         return isTranslucent ? themeSpec.getTranslucent() : themeSpec;
+    }
+
+    /** True for the literal "system" value, and for empty/unset (SYSTEM is the default). */
+    public static boolean isSystemTheme(String value) {
+        // Not TextUtils.isEmpty(): it's an unmocked Android stub under Robolectric-free JVM unit
+        // tests (returns the default `false` regardless of input), which would make this always
+        // resolve as non-system there. Plain Java has no such stub.
+        return SYSTEM.equals(value) || value == null || value.isEmpty();
     }
 
     @SuppressWarnings("unused")
@@ -80,7 +95,7 @@ public class ThemePreference extends Preference {
 
     @Override
     protected Object onGetDefaultValue(TypedArray a, int index) {
-        return LIGHT;
+        return SYSTEM;
     }
 
     @Override
@@ -88,7 +103,7 @@ public class ThemePreference extends Preference {
         super.onSetInitialValue(restorePersistedValue, defaultValue);
         mSelectedTheme = restorePersistedValue ? getPersistedString(null): (String) defaultValue;
         if (TextUtils.isEmpty(mSelectedTheme)) {
-            mSelectedTheme = LIGHT;
+            mSelectedTheme = SYSTEM;
         }
         setSummary(VALUES.get(mSelectedTheme).summary);
     }
@@ -115,8 +130,9 @@ public class ThemePreference extends Preference {
 
     @Override
     public boolean shouldDisableDependents() {
-        // assume only auto day-night is dependent
-        return !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
+        // assume only auto day-night is dependent; "System" already always follows day/night on
+        // its own (see Preferences.Theme.getAutoDayNightMode), making the toggle redundant for it
+        return isSystemTheme(mSelectedTheme) || !(VALUES.get(mSelectedTheme) instanceof DayNightSpec);
     }
 
     public static class ThemeSpec {

--- a/app/src/main/kotlin/com/growse/android/io/github/hidroh/materialistic/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/growse/android/io/github/hidroh/materialistic/LauncherActivity.kt
@@ -22,6 +22,11 @@ import android.os.Bundle
 class LauncherActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    // Reconciles the home-screen icon with the toolbar color preference, in case it changed
+    // (or the app was just installed) since the icon was last synced. Off the main thread since
+    // it touches disk via PackageManager; doesn't need to complete before the redirect below.
+    val appContext = applicationContext
+    Thread { Preferences.Theme.syncLauncherIcon(appContext) }.start()
     val launchScreens: Map<String, Class<out Activity>> =
         mapOf(
             getString(R.string.pref_launch_screen_value_top) to ListActivity::class.java,

--- a/app/src/main/kotlin/com/growse/android/io/github/hidroh/materialistic/LauncherActivity.kt
+++ b/app/src/main/kotlin/com/growse/android/io/github/hidroh/materialistic/LauncherActivity.kt
@@ -25,8 +25,11 @@ class LauncherActivity : Activity() {
     // Reconciles the home-screen icon with the toolbar color preference, in case it changed
     // (or the app was just installed) since the icon was last synced. Off the main thread since
     // it touches disk via PackageManager; doesn't need to complete before the redirect below.
+    // Passes the component that just launched this task so syncLauncherIcon never disables it -
+    // doing so would close this very task (see its kdoc).
     val appContext = applicationContext
-    Thread { Preferences.Theme.syncLauncherIcon(appContext) }.start()
+    val launchedViaComponent = intent.component
+    Thread { Preferences.Theme.syncLauncherIcon(appContext, launchedViaComponent) }.start()
     val launchScreens: Map<String, Class<out Activity>> =
         mapOf(
             getString(R.string.pref_launch_screen_value_top) to ListActivity::class.java,

--- a/app/src/main/res/drawable/ic_check_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_check_white_24dp.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2015 Ha Duy Trung
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/preference_color.xml
+++ b/app/src/main/res/layout/preference_color.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2015 Ha Duy Trung
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:minHeight="?attr/listPreferredItemHeight"
+    android:gravity="center_vertical"
+    android:paddingRight="?android:attr/scrollbarSize"
+    android:background="?attr/selectableItemBackground"
+    android:focusable="true"
+    tools:ignore="Overdraw">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="15dip"
+        android:layout_marginRight="6dip"
+        android:layout_marginTop="6dip">
+
+        <TextView android:id="@android:id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            android:textColor="?android:attr/textColorPrimary"
+            android:fadingEdge="horizontal" />
+
+        <TextView android:id="@android:id/summary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_alignLeft="@android:id/title"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
+            android:maxLines="4" />
+
+    </RelativeLayout>
+
+    <HorizontalScrollView
+        android:layout_marginTop="6dip"
+        android:layout_marginBottom="6dip"
+        android:scrollbarStyle="outsideInset"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/color_swatch_container"
+            android:orientation="horizontal"
+            android:paddingLeft="15dip"
+            android:paddingRight="15dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </HorizontalScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/preference_theme.xml
+++ b/app/src/main/res/layout/preference_theme.xml
@@ -131,6 +131,18 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
 
+            <!-- Same underlying style as Light: "System" only differs in that it always follows
+                 the OS's day/night setting (see Preferences.Theme.getAutoDayNightMode) rather
+                 than needing the separate "Auto day-night mode" toggle turned on manually. -->
+            <com.growse.android.io.github.hidroh.materialistic.widget.preference.ThemeView
+                android:id="@+id/theme_system"
+                android:theme="@style/AppTheme"
+                android:layout_marginTop="@dimen/margin"
+                android:layout_marginBottom="@dimen/margin"
+                android:layout_marginRight="@dimen/margin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/app/src/main/res/layout/story_view.xml
+++ b/app/src/main/res/layout/story_view.xml
@@ -118,7 +118,7 @@
         android:visibility="invisible"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:tint="@color/orange400" />
+        app:tint="@color/purple400" />
 
     <TextView
         android:id="@id/score"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/lightBlue700"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_blue_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/lightBlue700"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_brown.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_brown.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/brown500"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_brown_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_brown_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/brown500"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_indigo.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_indigo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/indigoA700"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_indigo_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_indigo_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/indigoA700"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/redA200"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_red_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/redA200"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_teal.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_teal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/teal500"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_teal_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_teal_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/teal500"/>
+    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- orange400 is actually Material purple; lighten by one step for dark mode -->
-    <color name="orange400">#BA68C8</color>
-</resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2015 Ha Duy Trung
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+    <!-- Wallpaper-derived (Material You) toolbar/accent color overlay, applied only when the
+         "System" swatch is chosen and Preferences.Theme confirms DynamicColors is actually
+         available on this device (Preferences.getPrimaryColorOverlay/getAccentColorOverlay).
+         Kept in a v31 resource qualifier, rather than the shared themes.xml, since
+         android:color/system_accent1_* only exists from API 31 onward: resolving it on an
+         older OS would crash, and a resource defined only under values-v31 simply can't be
+         looked up there, which is exactly the safety net we want. -->
+    <style name="PrimaryColorOverlay.System" parent="">
+        <item name="colorPrimary">@android:color/system_accent1_600</item>
+        <item name="colorPrimaryDark">@android:color/system_accent1_600</item>
+    </style>
+    <style name="AccentColorOverlay.System" parent="">
+        <item name="colorAccent">@android:color/system_accent1_600</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -227,6 +227,32 @@
         <item>@color/blueGrey500</item>
     </array>
 
+    <!-- Accent color picker swatches (shared by pref_primary_color and pref_accent_color) -->
+    <array name="accent_color_values">
+        <item>@color/purple400</item>
+        <item>@color/redA200</item>
+        <item>@color/indigoA700</item>
+        <item>@color/lightBlue700</item>
+        <item>@color/teal500</item>
+        <item>@color/brown500</item>
+    </array>
+    <string-array name="accent_color_names" translatable="false">
+        <item>purple</item>
+        <item>red</item>
+        <item>indigo</item>
+        <item>blue</item>
+        <item>teal</item>
+        <item>brown</item>
+    </string-array>
+    <string-array name="accent_color_labels">
+        <item>@string/color_purple</item>
+        <item>@string/color_red</item>
+        <item>@string/color_indigo</item>
+        <item>@string/color_blue</item>
+        <item>@string/color_teal</item>
+        <item>@string/color_brown</item>
+    </string-array>
+
     <!-- Swipe options -->
     <string-array name="pref_list_swipe_options">
         <item>@string/none</item>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,7 +28,9 @@
 
     <color name="red500">#F44336</color>
     <color name="redA100">#FF8A80</color>
-    <color name="redA200">#FF5252</color>
+    <!-- Was #FF5252 (Material Red A200); too low-contrast as text/icons on light
+         backgrounds, see https://github.com/growse/materialistic-nouveau/issues/58 -->
+    <color name="redA200">#D32F2F</color>
     <color name="purpleA400">#D500F9</color>
     <color name="indigoA700">#304FFE</color>
     <color name="lightBlue700">#0288D1</color>
@@ -43,8 +45,11 @@
     <color name="greenA700">#00C853</color>
     <color name="orange50">#F3E5F5</color>
     <color name="orange100">#E1BEE7</color>
-    <color name="orange300">#BA68C8</color>
-    <color name="orange400">#AB47BC</color>
+    <!-- These two are actually Material Purple, not orange; kept the misleading
+         names historically but bumped to a darker weight for contrast, see
+         https://github.com/growse/materialistic-nouveau/issues/58 -->
+    <color name="purple300">#9C27B0</color>
+    <color name="purple400">#7B1FA2</color>
     <color name="brown400">#8D6E63</color>
     <color name="brown800">#4E342E</color>
     <color name="lightGreen700">#689F38</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,6 +23,8 @@
     <dimen name="padding_asterisk">2dp</dimen>
     <dimen name="padding">8dp</dimen>
     <dimen name="margin">8dp</dimen>
+    <dimen name="color_swatch_size">36dp</dimen>
+    <dimen name="color_swatch_check_size">18dp</dimen>
     <dimen name="cardview_vertical_margin">4dp</dimen>
     <dimen name="cardview_horizontal_margin">8dp</dimen>
     <dimen name="cardview_min_height">64dp</dimen>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -58,6 +58,8 @@
     <string translatable="false" name="pref_text_size">pref_text_size</string>
     <string translatable="false" name="pref_theme">pref_theme</string>
     <string translatable="false" name="pref_daynight_auto">pref_daynight_auto</string>
+    <string translatable="false" name="pref_primary_color">pref_primary_color</string>
+    <string translatable="false" name="pref_accent_color">pref_accent_color</string>
     <string translatable="false" name="pref_widget_theme">pref_widget_theme</string>
     <string translatable="false" name="pref_widget_section">pref_widget_section</string>
     <string translatable="false" name="pref_widget_query">pref_widget_query</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="color_blue">Blue</string>
     <string name="color_teal">Teal</string>
     <string name="color_brown">Brown</string>
+    <string name="color_system">System</string>
     <string name="pref_search_sort_title">Sort by</string>
     <string name="pref_search_sort_value_recent">recent</string>
     <string name="pref_search_sort_value_default">default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,14 @@
     <string name="pref_story_display_title">Default open</string>
     <string name="pref_theme_title">Theme</string>
     <string name="pref_daynight_title">Auto day-night mode</string>
+    <string name="pref_primary_color_title">Toolbar color</string>
+    <string name="pref_accent_color_title">Accent color</string>
+    <string name="color_purple">Purple</string>
+    <string name="color_red">Red</string>
+    <string name="color_indigo">Indigo</string>
+    <string name="color_blue">Blue</string>
+    <string name="color_teal">Teal</string>
+    <string name="color_brown">Brown</string>
     <string name="pref_search_sort_title">Sort by</string>
     <string name="pref_search_sort_value_recent">recent</string>
     <string name="pref_search_sort_value_default">default</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="text_size_large">Large</string>
     <string name="text_size_extra_large">Extra large</string>
     <string name="readability_failed">Unable to parse article</string>
+    <string name="theme_system">System</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
     <string name="theme_black">Black</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -68,7 +68,7 @@
         <item name="android:layout_width">match_parent</item>
     </style>
     <style name="ThemeOverlay.App.Rating" parent="ThemeOverlay.AppCompat.Light">
-        <item name="colorAccent">@color/orange400</item>
+        <item name="colorAccent">@color/purple400</item>
     </style>
 
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,8 +22,8 @@
     <!-- =================== -->
     <style name="BaseAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- color palette -->
-        <item name="colorPrimary">@color/orange300</item>
-        <item name="colorPrimaryDark">@color/orange400</item>
+        <item name="colorPrimary">@color/purple300</item>
+        <item name="colorPrimaryDark">@color/purple400</item>
         <item name="colorAccent">@color/redA200</item>
         <item name="colorCardBackground">@color/grey100</item>
         <item name="colorCardHighlight">@color/orange100</item>
@@ -97,8 +97,8 @@
 
     <style name="BaseAppTheme.DayNight" parent="BaseAppTheme.DayNight.NoActionBar">
         <!-- color palette -->
-        <item name="colorPrimary">@color/orange300</item>
-        <item name="colorPrimaryDark">@color/orange400</item>
+        <item name="colorPrimary">@color/purple300</item>
+        <item name="colorPrimaryDark">@color/purple400</item>
         <item name="colorAccent">@color/redA200</item>
         <item name="colorCardBackground">@color/grey100</item>
         <item name="colorCardHighlight">@color/orange100</item>
@@ -147,8 +147,8 @@
     </style>
 
     <style name="Sepia">
-        <item name="colorPrimary">@color/orange300</item>
-        <item name="colorPrimaryDark">@color/orange400</item>
+        <item name="colorPrimary">@color/purple300</item>
+        <item name="colorPrimaryDark">@color/purple400</item>
         <item name="colorCardBackground">@color/orange50</item>
         <item name="android:textColorPrimary">@color/brown800</item>
         <item name="android:textColorSecondary">@color/brown400</item>
@@ -168,8 +168,8 @@
     </style>
 
     <style name="Solarized">
-        <item name="colorPrimary">@color/orange300</item>
-        <item name="colorPrimaryDark">@color/orange400</item>
+        <item name="colorPrimary">@color/purple300</item>
+        <item name="colorPrimaryDark">@color/purple400</item>
         <item name="colorAccent">@color/solarizedOrange</item>
         <item name="colorCardBackground">@color/solarizedBase3</item>
         <item name="colorCardHighlight">@color/solarizedBase2</item>
@@ -194,11 +194,60 @@
     <style name="Solarized.Dark" parent="BaseDarkSolarized">
     </style>
 
+    <!-- ============================================================= -->
+    <!-- User-chosen toolbar/accent color overlays (see arrays.xml's   -->
+    <!-- accent_color_names/accent_color_values, applied by            -->
+    <!-- Preferences.Theme.apply() on top of the selected theme)       -->
+    <!-- ============================================================= -->
+    <style name="PrimaryColorOverlay.Purple" parent="">
+        <item name="colorPrimary">@color/purple300</item>
+        <item name="colorPrimaryDark">@color/purple400</item>
+    </style>
+    <style name="PrimaryColorOverlay.Red" parent="">
+        <item name="colorPrimary">@color/redA200</item>
+        <item name="colorPrimaryDark">@color/redA200</item>
+    </style>
+    <style name="PrimaryColorOverlay.Indigo" parent="">
+        <item name="colorPrimary">@color/indigoA700</item>
+        <item name="colorPrimaryDark">@color/indigoA700</item>
+    </style>
+    <style name="PrimaryColorOverlay.Blue" parent="">
+        <item name="colorPrimary">@color/lightBlue700</item>
+        <item name="colorPrimaryDark">@color/lightBlue700</item>
+    </style>
+    <style name="PrimaryColorOverlay.Teal" parent="">
+        <item name="colorPrimary">@color/teal500</item>
+        <item name="colorPrimaryDark">@color/teal600</item>
+    </style>
+    <style name="PrimaryColorOverlay.Brown" parent="">
+        <item name="colorPrimary">@color/brown500</item>
+        <item name="colorPrimaryDark">@color/brown800</item>
+    </style>
+
+    <style name="AccentColorOverlay.Purple" parent="">
+        <item name="colorAccent">@color/purple400</item>
+    </style>
+    <style name="AccentColorOverlay.Red" parent="">
+        <item name="colorAccent">@color/redA200</item>
+    </style>
+    <style name="AccentColorOverlay.Indigo" parent="">
+        <item name="colorAccent">@color/indigoA700</item>
+    </style>
+    <style name="AccentColorOverlay.Blue" parent="">
+        <item name="colorAccent">@color/lightBlue700</item>
+    </style>
+    <style name="AccentColorOverlay.Teal" parent="">
+        <item name="colorAccent">@color/teal500</item>
+    </style>
+    <style name="AccentColorOverlay.Brown" parent="">
+        <item name="colorAccent">@color/brown500</item>
+    </style>
+
     <!-- =================== -->
     <!-- Alert dialog themes -->
     <!-- =================== -->
     <style name="AppAlertDialog" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorPrimary">@color/orange400</item>
+        <item name="colorPrimary">@color/purple400</item>
         <item name="colorAccent">@color/redA200</item>
         <item name="android:textColorPrimary">@color/blackT87</item>
         <item name="android:textColorSecondary">@color/blackT50</item>
@@ -221,7 +270,7 @@
     </style>
 
     <style name="AppAlertDialog.Sepia">
-        <item name="colorPrimary">@color/orange300</item>
+        <item name="colorPrimary">@color/purple300</item>
         <item name="android:textColorPrimary">@color/brown800</item>
         <item name="android:textColorSecondary">@color/brown400</item>
         <item name="colorCardBackground">@color/orange50</item>
@@ -236,7 +285,7 @@
     </style>
 
     <style name="AppAlertDialog.Solarized">
-        <item name="colorPrimary">@color/orange300</item>
+        <item name="colorPrimary">@color/purple300</item>
         <item name="android:textColorPrimary">@color/solarizedBase01</item>
         <item name="android:textColorSecondary">@color/solarizedBase1</item>
         <item name="colorCardBackground">@color/solarizedBase3</item>
@@ -268,7 +317,7 @@
     </style>
 
     <style name="AppBottomSheetDialog.Sepia">
-        <item name="colorPrimary">@color/orange300</item>
+        <item name="colorPrimary">@color/purple300</item>
         <item name="android:textColorPrimary">@color/brown800</item>
         <item name="android:textColorSecondary">@color/brown400</item>
         <item name="android:colorBackground">@color/orange50</item>
@@ -282,7 +331,7 @@
     </style>
 
     <style name="AppBottomSheetDialog.Solarized">
-        <item name="colorPrimary">@color/orange300</item>
+        <item name="colorPrimary">@color/purple300</item>
         <item name="android:textColorPrimary">@color/solarizedBase01</item>
         <item name="android:textColorSecondary">@color/solarizedBase1</item>
         <item name="android:colorBackground">@color/solarizedBase3</item>

--- a/app/src/main/res/xml/preferences_display.xml
+++ b/app/src/main/res/xml/preferences_display.xml
@@ -24,7 +24,7 @@
     <com.growse.android.io.github.hidroh.materialistic.preference.ThemePreference
         android:key="@string/pref_theme"
         android:title="@string/pref_theme_title"
-        android:defaultValue="light" />
+        android:defaultValue="system" />
 
     <androidx.preference.SwitchPreferenceCompat
         app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/preferences_display.xml
+++ b/app/src/main/res/xml/preferences_display.xml
@@ -33,6 +33,16 @@
         android:title="@string/pref_daynight_title"
         android:defaultValue="false" />
 
+    <com.growse.android.io.github.hidroh.materialistic.preference.ColorPreference
+        android:key="@string/pref_primary_color"
+        android:title="@string/pref_primary_color_title"
+        android:defaultValue="purple" />
+
+    <com.growse.android.io.github.hidroh.materialistic.preference.ColorPreference
+        android:key="@string/pref_accent_color"
+        android:title="@string/pref_accent_color_title"
+        android:defaultValue="red" />
+
     <com.growse.android.io.github.hidroh.materialistic.preference.FontSizePreference
         android:key="@string/pref_text_size"
         android:title="@string/pref_text_size_title"

--- a/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/PreferencesTest.kt
+++ b/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/PreferencesTest.kt
@@ -1,0 +1,15 @@
+package com.growse.android.io.github.hidroh.materialistic
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class PreferencesThemeDefaultColorChoiceTest :
+    StringSpec({
+      // DynamicColors.isDynamicColorAvailable() can't be true in a plain JVM unit test (no real
+      // Build.VERSION.SDK_INT), so this only exercises the "unavailable" fallback path - the
+      // "system" path is covered by the instrumented DisplayPreferencesActivityTest instead.
+      "falls back to the given default when dynamic color is unavailable" {
+        Preferences.Theme.defaultColorChoice("purple") shouldBe "purple"
+        Preferences.Theme.defaultColorChoice("red") shouldBe "red"
+      }
+    })

--- a/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivityTest.kt
+++ b/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/ReleaseNotesActivityTest.kt
@@ -1,0 +1,31 @@
+package com.growse.android.io.github.hidroh.materialistic
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ReleaseNotesActivityTest :
+    StringSpec({
+      "a single line of notes is wrapped in a paragraph" {
+        ReleaseNotesActivity.buildNotesBody("Fixed a bug.", "unused") shouldBe "<p>Fixed a bug.</p>"
+      }
+
+      "multiple lines each become their own paragraph" {
+        ReleaseNotesActivity.buildNotesBody("First change.\nSecond change.", "unused") shouldBe
+            "<p>First change.</p><p>Second change.</p>"
+      }
+
+      "blank lines between real lines are dropped" {
+        ReleaseNotesActivity.buildNotesBody("First change.\n\n\nSecond change.", "unused") shouldBe
+            "<p>First change.</p><p>Second change.</p>"
+      }
+
+      "empty notes fall back to the unavailable message" {
+        ReleaseNotesActivity.buildNotesBody("", "No release notes available.") shouldBe
+            "<p>No release notes available.</p>"
+      }
+
+      "blank (whitespace-only) notes also fall back to the unavailable message" {
+        ReleaseNotesActivity.buildNotesBody("   \n  ", "No release notes available.") shouldBe
+            "<p>No release notes available.</p>"
+      }
+    })

--- a/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/preference/ThemePreferenceTest.kt
+++ b/app/src/test/kotlin/com/growse/android/io/github/hidroh/materialistic/preference/ThemePreferenceTest.kt
@@ -1,0 +1,25 @@
+package com.growse.android.io.github.hidroh.materialistic.preference
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ThemePreferenceIsSystemThemeTest :
+    StringSpec({
+      "the literal system value is the system theme" {
+        ThemePreference.isSystemTheme("system") shouldBe true
+      }
+
+      "an empty value is the system theme, since System is the default" {
+        ThemePreference.isSystemTheme("") shouldBe true
+      }
+
+      "a null value is the system theme, since System is the default" {
+        ThemePreference.isSystemTheme(null) shouldBe true
+      }
+
+      "any other theme value is not the system theme" {
+        ThemePreference.isSystemTheme("light") shouldBe false
+        ThemePreference.isSystemTheme("dark") shouldBe false
+        ThemePreference.isSystemTheme("sepia") shouldBe false
+      }
+    })


### PR DESCRIPTION
## Summary

- The default "purple" toolbar color (`colorPrimary`/`colorPrimaryDark`) was Material Purple 300/400 stored under misleadingly-named `orange300`/`orange400` resources — a light weight meant for black-text pairings, but used here with the white toolbar text/icons `AppToolbarTheme` expects. Renamed to `purple300`/`purple400` and bumped to Purple 500/700, the weight Material's own guidelines pair with white text. This also fixes the Sepia/Solarized themes' toolbar staying purple and low-contrast under dark mode, which `values-night/colors.xml`'s one-step-lighter hack (now removed) was only partially papering over.
- The default "salmon" accent (`colorAccent` = `redA200`) is bumped from Red A200 to Red 700 for the same reason: text/link contrast against light backgrounds.
- New **Toolbar color** and **Accent color** preferences (Settings → Display) let users pick from a 6-swatch Material palette instead of being stuck with the above, applied as a theme overlay on top of whichever theme (Light/Dark/Black/Sepia/Green/Solarized) is selected, taking effect immediately via the same live-restart mechanism the existing theme picker uses.
- On API 31+ where Material You dynamic color is actually available (`DynamicColors.isDynamicColorAvailable()`, not just an SDK check), both pickers get a 7th **System** swatch derived from the device wallpaper (`@android:color/system_accent1_600`). The overlay styles referencing that resource live in a `values-v31` qualifier so they're simply unresolvable pre-31 rather than crashing, and `Preferences.Theme` falls back to Purple/Red if "system" is ever persisted without dynamic color being available.
- Both color pickers now **default to System** wherever it's available (`Preferences.Theme.defaultColorChoice`), rather than defaulting to the fixed Purple/Red swatches — those remain the default only where dynamic color isn't available. This is a real default for everyone, not just people who open Settings: `Preferences.Theme.apply()`'s own fallback uses the same logic.
- The **Theme picker itself also gets a System option, and it's the default**. It's a `DayNightSpec` identical to "Light", except `Preferences.Theme.getAutoDayNightMode()` forces `MODE_NIGHT_FOLLOW_SYSTEM` for it unconditionally rather than depending on the separate "Auto day-night mode" toggle — so out of the box, with nothing configured, the app follows the OS's light/dark setting immediately. That toggle stays fully independent for every other DayNight-capable theme (e.g. "Sepia + auto day-night" is still an explicit combination you can opt into), and is greyed out while System is selected since it'd otherwise be redundant.
- The **home-screen launcher icon tracks the toolbar color choice**. `.LauncherActivity` keeps its existing purple/monochrome-capable icon for "Purple" and "System" (the latter lets the OS's own wallpaper-based icon theming handle it, for users with that on); the other five swatches each get a disabled-by-default `activity-alias` with a recolored adaptive icon (same foreground artwork, solid-color background), toggled via `PackageManager` in `Preferences.Theme.syncLauncherIcon()`.
- **Fixed a real crash found via a user-supplied logcat trace**: disabling an `activity-alias` that's the origin of the currently-running task closes that task outright (`DONT_KILL_APP` only protects the process, not the task) — so switching the toolbar color away from whichever color's icon you'd actually launched the app from could kill the running app. `syncLauncherIcon()` now takes the component that launched the current task and never disables it, deferring that one disable to the next cold start; the "live" sync on preference change was removed entirely since a child activity has no reliable way to know what launched the task's root. The icon now only updates on the next cold start.

Fixes #58

## Test plan

- [x] `./gradlew lint app:testDebugUnitTest ktfmtCheck` all pass
- [x] `./gradlew assembleDebug` succeeds
- [x] Kaspresso coverage: `DisplayPreferencesActivityTest` (theme/toolbar/accent default summaries — including same-label collisions between pickers, tapping a swatch persists and updates independently of the other pickers, the System swatch round-trip when dynamic color is available), `LauncherIconSyncTest` (exactly one launcher component enabled at a time matching the persisted toolbar color, and a regression test that the component which launched the current task is never disabled), plus strengthened `AboutActivityTest` (links to this fork) and `ReleaseNotesActivityTest` (marks release notes seen); notes-body formatting, `defaultColorChoice`'s fallback path, and `ThemePreference.isSystemTheme` covered by JVM unit tests
- [x] Manually verified on an API 37 emulator: default purple/red render with visibly better contrast; all three pickers default to System; toggling the emulator's system dark mode flips the whole app live with zero configuration; switching the toolbar color live-updates the in-app toolbar and (on the next cold start) the home-screen icon; reproduced the exact crash sequence from the logcat trace (toolbar → Red, force-stop, relaunch via the resulting Red icon, switch to Teal from inside that task) and confirmed no more task-closure
- [x] Manually verified on a separate API 26 emulator: only the original 6 color swatches show (no System), colors default to Purple/Red, no crash, and the icon-swap mechanism itself still works there (only the "System" choice is API-gated, not the alias-switching)

Note: found `ReleaseNotesActivityTest.okButtonDismissesActivity` already failing on `main` independent of this branch (reproduces in isolation on a clean emulator) — not fixed here, flagging separately.